### PR TITLE
academy boxes, grammar, and faculty fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,7 @@ GEM
     webrick (1.8.1)
 
 PLATFORMS
+  arm64-darwin-22
   arm64-darwin-23
   x64-mingw-ucrt
 

--- a/_layouts/athletics.html
+++ b/_layouts/athletics.html
@@ -103,7 +103,7 @@ layout: default
     <h2 id="coach-info">Coach Contact Information</h2>
 
     {{ content }}
-    <a class="top-link" href="#top"><i class="fa-solid fa-circle-up"></i>Back to top</a>
+    
   </section>
 
 </article>

--- a/_sass/techhigh/templates/department-pages.scss
+++ b/_sass/techhigh/templates/department-pages.scss
@@ -114,10 +114,14 @@
 
     .courses{
         .summer-work{
+            color: white;
+            background-color: $primary;
+            padding: 20px;
             border-radius: 10px;
-            margin-top: 0;
-            background-color: $light-grey;
-            color: black;
+        ul {
+            padding: 0;
+            margin-left: 20px;
+        }
         }
     }
 

--- a/_sass/techhigh/templates/faculty.scss
+++ b/_sass/techhigh/templates/faculty.scss
@@ -21,3 +21,7 @@
         }
     }
 }
+
+.post-title {
+    color: $primary;
+}

--- a/_summer_work/math.md
+++ b/_summer_work/math.md
@@ -11,7 +11,7 @@ tags: [calculating, numbers, relationships, summer+work]
 1. Log into Delta Math
 2. Click the Tools and then click on Manage login and Courses
 3. Add the following teacher code: 431665
-4. Select the courses you will be taking next year and you should be all set to start working on completing your summer math work. If your not sure what class to pick, check your student portal and look at next years schedule
+4. Select the courses you will be taking next year and you should be all set to start working on completing your Summer Math work. If your not sure what class to pick, check your student portal and look at next years schedule
 5. ALL incoming 9th grade students will all select the class "Entering 9th Grade 2023 - 24" regardless if they are taking Algebra 1 or Geometry.
 </div>
 
@@ -20,7 +20,7 @@ tags: [calculating, numbers, relationships, summer+work]
 1. Log into Delta Math
 2. Click the Tools and then click on Manage login and Courses
 3. Add the following teacher code: 431665
-4. Select the courses you will be taking next year and you should be all set to start working on completing your summer math work. If your not sure what class to pick, check your student portal and look at next years schedule
+4. Select the courses you will be taking next year and you should be all set to start working on completing your Summer Math work. If your not sure what class to pick, check your student portal and look at next years schedule
 </div>
 
 <div class="juniors" markdown="1">
@@ -28,7 +28,7 @@ tags: [calculating, numbers, relationships, summer+work]
 1. Log into Delta Math
 2. Click the Tools and then click on Manage login and Courses
 3. Add the following teacher code: 431665
-4. Select the courses you will be taking next year and you should be all set to start working on completing your summer math work. If your not sure what class to pick, check your student portal and look at next years schedule
+4. Select the courses you will be taking next year and you should be all set to start working on completing your Summer Math work. If your not sure what class to pick, check your student portal and look at next years schedule
 </div>
 
 <div class="seniors" markdown="1">
@@ -46,7 +46,7 @@ You will be practicing basic skills needed for the math class that you will be t
 Upon returning to Worcester Tech after the summer, your results from your Summer Math work will be given to the Math teacher you will have for the 2023-24 School year.
 ALL students will redcieve a TEST grade in their MATH class upon return to school in the fall based on the completion of the Summer Math.
 
-Any questions regarding Summer MAth can be directed to Mr. Lynch. His email is: lynchse@worcesterschools.net
+Any questions regarding Summer Math can be directed to Mr. Lynch. His email is: lynchse@worcesterschools.net
 </div>
 
 <br>


### PR DESCRIPTION
**Changes:**

- Academy pages no longer have the grey box. Instead, they have the same style box that the box above it has.
- Changed some capitalization and grammar of some words on the Math page(s).
- Made the title for Faculty have the $primary color. It is now navy blue, rather than black.